### PR TITLE
Fix/server not accepting connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-socks5"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jonathan Dizdarevic <dizzda@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ description = "Fast SOCKS5 client/server implementation written in Rust async/.a
 repository = "https://github.com/dizda/fast-socks5"
 
 [dependencies]
-futures = "0.3.6"
+futures = "0.3.8"
 log = "0.4"
-async-std = { version = "1.6.5", features = ["default"] }
+async-std = { version = "1.8.0", features = ["default"] }
 anyhow = "1.0"
 thiserror = "1.0"
 


### PR DESCRIPTION
This PR 

- updates the dependencies to their latest versions
- fixes #6 by borrowing main parts of the Stream trait implementation from `TcpListener`'s Stream implementation

the result of the examples described in #6 looks now like this:

```sh
curl --socks5 127.0.0.1:1337 https://www.google.com
<!doctype html><html itemscope="" itemtype="http://schema.org/WebPage" lang="de"><head><meta content="text/html; charset=UTF-8" http-equiv="Content-Type"><meta content="/logos/doodles/2020/december-holidays-days-2-30-6753651837108830.3-law.gif" itemprop="image"><meta content="Eine sch�ne Dezemberzeit! " property="twitter:title"><meta content="Eine sch�ne Dezemberzeit! #GoogleDoodle" property="twitter:description"><meta content="Eine sch�ne Dezemberzeit! #GoogleDoodle" property="og:description"><meta content="summary_large_image" property="twitter:card"><meta content="@GoogleDoodles" property="twitter:site"><meta content="https://www.google.com/logos/doodles/2020/december-holidays-days-2-30-6753651837108830.3-2xa.gif" property="twitter:image"><meta content="https://www.google.com/logos/doodles/2020/december-holidays-days-2-30-6753651837108830.3-2xa.gif" property="og:image"><meta content="1100" property="og:image:width"><meta content="440" property="og:image:height"><meta content="https://www.google.com/logos/doodles/2020/december-holidays-days-2-30-6753651837108830.3-2xa.gif" property="og:url"><meta content="video.other" property="og:type"><title>Google</title><script nonce="zegZ+cQubMnvbcr1y2gz4A==">(function(){window.google={kEI:'uhneX6D4DJG9lwT566roCg',kEXPI:'0,1359409,731,223,5104,207,3204,10,1144,82,364,1499,817,383,246,5,1354,4414,3,65,768,218,1263,1093,433,902,1423,7,1046,1087,1069,978,1112997,1232,1196514,537,6,328978,13677,4855,32692,16114,17444,1953,9287,9188,8384,1325,3533,1362,9291,3028,4739,12841,4020,978,7931,5297,2054,920,873,4192,6430,14527,236,4281,2778,919,1832,445,8,85,2711,1593,1279,2212,241,289,149,1103,840,517,1466,58,155,4101,109,203,1137,2,2669,2023,2297,1947,2229,93,330,1282,2943,2247,3599,3227,420,2425,7,5599,6755,5096,598,7279,4928,108,3407,908,2,941,2614,2397,7470,3275,1,2,576,970,865,6,2545,1796,277,151,4996,992,7985,4,1528,2304,224,1012,271,87

....
```

and the server side logs the following:

```sh
RUST_LOG=debug cargo run --example server -- --listen-addr 127.0.0.1:1337 no-auth
   Compiling fast-socks5 v0.4.0 (/Users/d34dl0ck/workspaces/experimenal/foxglove/research/fast-socks5)
    Finished dev [unoptimized + debuginfo] target(s) in 3.37s
     Running `target/debug/examples/server --listen-addr '127.0.0.1:1337' no-auth`
[2020-12-19T15:18:15Z WARN  server] No authentication has been set!
[2020-12-19T15:18:15Z INFO  server] Listen for socks connections @ 127.0.0.1:1337
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] incoming connection from peer 127.0.0.1:55892 @ 127.0.0.1:1337
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] Handshake headers: [version: 5, methods len: 2]
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] methods supported sent by the client: [0, 1]
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] Reply with method AuthenticationMethod::None (0)
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] Request: [version: 5, command: 1, rev: 0, address_type: 1]
[2020-12-19T15:18:17Z DEBUG fast_socks5::util::target_addr] Address type `IPv4`
[2020-12-19T15:18:17Z DEBUG fast_socks5::server] Request target is 173.194.222.104:443
[2020-12-19T15:18:18Z DEBUG fast_socks5::server] Connected to remote destination
[2020-12-19T15:18:18Z DEBUG fast_socks5::server] Wrote success
[2020-12-19T15:18:18Z ERROR fast_socks5::server] local closed -> remote target with error Os { code: 54, kind: ConnectionReset, message: "Connection reset by peer" }
^C
```

I wanted to note that tests are still failing as they did before this PR. I do not attempt to fix them. 