### PR TITLE
add simple configuration for bind address of outgoing sockets

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,6 +7,8 @@ use fast_socks5::{
     Result, SocksError,
 };
 use std::future::Future;
+use std::net::SocketAddr;
+use std::str::FromStr;
 use structopt::StructOpt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::task;
@@ -41,6 +43,10 @@ struct Opt {
     /// Don't perform the auth handshake, send directly the command request
     #[structopt(short = "k", long)]
     pub skip_auth: bool,
+
+    /// Outgoing address
+    #[structopt(short, long)]
+    pub outgoing_addr: Option<String>,
 }
 
 /// Choose the authentication type
@@ -75,6 +81,10 @@ async fn spawn_socks_server() -> Result<()> {
     let mut config = Config::default();
     config.set_request_timeout(opt.request_timeout);
     config.set_skip_auth(opt.skip_auth);
+
+    if let Some(outgoing_addr) = opt.outgoing_addr {
+        config.set_outgoing_addr(Some(SocketAddr::from_str(&outgoing_addr)?));
+    }
 
     match opt.auth {
         AuthMode::NoAuth => warn!("No authentication has been set!"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod util;
 
 use std::fmt;
 use std::io;
+use std::net::AddrParseError;
 use thiserror::Error;
 
 #[rustfmt::skip]
@@ -112,6 +113,8 @@ pub enum SocksError {
 
     #[error("Argument input error: `{0}`.")]
     ArgumentInputError(&'static str),
+    #[error("Address parse error: `{0}`.")]
+    AddrParseError(#[from] AddrParseError),
 
     //    #[error("Other: `{0}`.")]
     #[error(transparent)]


### PR DESCRIPTION
when specified like `--outgoing-addr=1.2.3.4:0`, outbound sockets will be bound to `1.2.3.4` before connecting. there are cases where a specific port may be desired instead of 0 for auto-select, but most uses cases call for 0, so i can add a fallback to parse the argument as an `IpAddr` (and constructing a `SocketAddr` with port 0) if parsing as `SocketAddr` fails. just wanted to see what you think of the general concept first though