### PR TITLE
Patch/11 support client request timeout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -19,8 +19,8 @@ const MAX_ADDR_LEN: usize = 260;
 
 #[derive(Debug)]
 pub struct Config {
-    /// Timeout of the command request
-    request_timeout: Option<u64>,
+    /// Timeout of the socket connect
+    connect_timeout: Option<u64>,
     /// Avoid useless roundtrips if we don't need the Authentication layer
     /// make sure to also activate it on the server side.
     skip_auth: bool,
@@ -28,14 +28,14 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Config { request_timeout: None, skip_auth: false }
+        Config { connect_timeout: None, skip_auth: false }
     }
 }
 
 impl Config {
-    /// How much time it should wait until the request timeout.
-    pub fn set_request_timeout(&mut self, n: u64) -> &mut Self {
-        self.request_timeout = Some(n);
+    /// How much time it should wait until the socket connect times out.
+    pub fn set_connect_timeout(&mut self, n: u64) -> &mut Self {
+        self.connect_timeout = Some(n);
         self
     }
 
@@ -598,9 +598,9 @@ impl Socks5Stream<TcpStream> {
             .to_socket_addrs()?
             .next()
             .context("unreachable")?;
-        let socket = match config.request_timeout {
+        let socket = match config.connect_timeout {
             None => tcp_connect(addr).await?,
-            Some(request_timeout) => tcp_connect_with_timeout(addr, request_timeout).await?,
+            Some(connect_timeout) => tcp_connect_with_timeout(addr, connect_timeout).await?,
         };
         info!("Connected @ {}", &socket.peer_addr()?);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,8 @@ pub enum ReplyError {
     HostUnreachable,
     #[error("Connection refused")]
     ConnectionRefused,
+    #[error("Connection timeout")]
+    ConnectionTimeout,
     #[error("TTL expired")]
     TtlExpired,
     #[error("Command not supported")]
@@ -192,6 +194,7 @@ impl ReplyError {
             ReplyError::NetworkUnreachable      => consts::SOCKS5_REPLY_NETWORK_UNREACHABLE,
             ReplyError::HostUnreachable         => consts::SOCKS5_REPLY_HOST_UNREACHABLE,
             ReplyError::ConnectionRefused       => consts::SOCKS5_REPLY_CONNECTION_REFUSED,
+            ReplyError::ConnectionTimeout       => consts::SOCKS5_REPLY_TTL_EXPIRED,
             ReplyError::TtlExpired              => consts::SOCKS5_REPLY_TTL_EXPIRED,
             ReplyError::CommandNotSupported     => consts::SOCKS5_REPLY_COMMAND_NOT_SUPPORTED,
             ReplyError::AddressTypeNotSupported => consts::SOCKS5_REPLY_ADDRESS_TYPE_NOT_SUPPORTED,

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -51,7 +51,7 @@ pub async fn tcp_connect_with_timeout<T>(addr: T, request_timeout_s: u64) -> Res
     let fut = tcp_connect(addr);
     match timeout(Duration::from_secs(request_timeout_s), fut).await {
         Ok(result) => result,
-        Err(_) => Err(ReplyError::TtlExpired.into()),
+        Err(_) => Err(ReplyError::ConnectionTimeout.into()),
     }
 }
 

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -1,3 +1,9 @@
+use crate::{ReplyError, Result};
+use tokio::io::ErrorKind as IOErrorKind;
+use tokio::time::timeout;
+use tokio::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
 /// Easy to destructure bytes buffers by naming each fields:
 ///
 /// # Examples (before)
@@ -37,4 +43,38 @@ macro_rules! ready {
             std::task::Poll::Pending => return std::task::Poll::Pending,
         }
     };
+}
+
+pub async fn tcp_connect_with_timeout<T>(addr: T, request_timeout_s: u64) -> Result<TcpStream>
+    where T: ToSocketAddrs,
+{
+    let fut = tcp_connect(addr);
+    match timeout(Duration::from_secs(request_timeout_s), fut).await {
+        Ok(result) => result,
+        Err(_) => Err(ReplyError::TtlExpired.into()),
+    }
+}
+
+pub async fn tcp_connect<T>(addr: T) -> Result<TcpStream>
+    where T: ToSocketAddrs,
+{
+    match TcpStream::connect(addr).await {
+        Ok(o) => Ok(o),
+        Err(e) => match e.kind() {
+            // Match other TCP errors with ReplyError
+            IOErrorKind::ConnectionRefused => {
+                Err(ReplyError::ConnectionRefused.into())
+            }
+            IOErrorKind::ConnectionAborted => {
+                Err(ReplyError::ConnectionNotAllowed.into())
+            }
+            IOErrorKind::ConnectionReset => {
+                Err(ReplyError::ConnectionNotAllowed.into())
+            }
+            IOErrorKind::NotConnected => {
+                Err(ReplyError::NetworkUnreachable.into())
+            }
+            _ => Err(e.into()), // #[error("General failure")] ?
+        },
+    }
 }


### PR DESCRIPTION
Here you go. this resolves #11.
Resolved it as a thank you for making this library, it fulfils my direct needs,
and shows production value.

Also, I do want a request timeout myself on client side, as part of my proxy-gateway project.

There are no unit tests, so cannot run those. But all your three examples do run.