### PR TITLE
Typo fix, forbid unsafe code

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,3 @@
-#[forbid(unsafe_code)]
 use crate::read_exact;
 use crate::util::target_addr::{read_address, TargetAddr, ToTargetAddr};
 use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
```
error: useless lint attribute
 --> src\lib.rs:1:1
  |
1 | #[forbid(unsafe_code)]
  | ^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![forbid(unsafe_code)]`
  |
  = note: `#[deny(clippy::useless_attribute)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute

error: useless lint attribute
 --> src\client.rs:1:1
  |
1 | #[forbid(unsafe_code)]
  | ^^^^^^^^^^^^^^^^^^^^^^ help: if you just forgot a `!`, use: `#![forbid(unsafe_code)]`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_attribute
```

`#![forbid(unsafe_code)]` in `lib.rs` is crate-level forbid of unsafe code