### PR TITLE
fix: Add macros feature to tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ socks4 = []
 
 [dependencies]
 log = "0.4"
-tokio = { version = "1.17.0", features = ["io-util", "net", "time"] }
+tokio = { version = "1.17.0", features = ["io-util", "net", "time", "macros"] }
 anyhow = "1.0"
 thiserror = "1.0"
 tokio-stream = "0.1.8"


### PR DESCRIPTION
This line is in the server code:

https://github.com/dizda/fast-socks5/blob/c4fb9c46e362e1653094e073839f81944ee37f76/src/server.rs#L22

But the macros feature isn't enabled in Cargo.toml. When publishing a crate with this library embedded, I encountered the following error:

```
error[E0432]: unresolved import `tokio::try_join`
  --> /Users/amaury/.cargo/registry/src/github.com-1ecc6299db9ec823/fast-socks5-0.8.0/src/server.rs:22:5
   |
22 | use tokio::try_join;
   |     ^^^^^^^^^^^^^^^ no `try_join` in the root

error: cannot determine resolution for the macro `try_join`
   --> /Users/amaury/.cargo/registry/src/github.com-1ecc6299db9ec823/fast-socks5-0.8.0/src/server.rs:701:11
    |
701 |     match try_join!(req_fut, res_fut) {
    |           ^^^^^^^^
    |
    = note: import resolution is stuck, try simplifying macro imports

For more information about this error, try `rustc --explain E0432`.
```

This PR aims to fix this error.