### PR TITLE
Update Tokio version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ socks4 = []
 
 [dependencies]
 log = "0.4"
-tokio = { version = "1.20.1", features = ["io-util", "net", "time", "macros"] }
+tokio = { version = "1.25.0", features = ["io-util", "net", "time", "macros"] }
 anyhow = "1.0"
 thiserror = "1.0"
 tokio-stream = "0.1.9"
@@ -24,7 +24,7 @@ tokio-stream = "0.1.9"
 [dev-dependencies]
 env_logger = "0.9"
 structopt = "0.3"
-tokio = { version = "1.20.1", features = ["io-util", "net", "time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.25.0", features = ["io-util", "net", "time", "rt-multi-thread", "macros"] }
 tokio-test = "0.4.2"
 
 [[example]]


### PR DESCRIPTION
I couldn't get `fast-socks5` to work with new Tokio versions, unless I updated the project's dependencies versions as well.

I think this is good hygiene and best practices overall, with no harm. Let me know what you think!