### PR TITLE
Add into_inner on Socks5Socket

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -249,6 +249,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Socks5Socket<T> {
         Ok(self)
     }
 
+    /// Consumes the `Socks5Socket`, returning the wrapped stream.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
     /// Read the authentication method provided by the client.
     /// A client send a list of methods that he supports, he could send
     ///


### PR DESCRIPTION
This function allows the caller to get the wrapped stream. In my use case I'm passing in my own wrapped TcpStream, and I would like it back once the session has finished.