### PR TITLE
Convert authentication trait to associated async trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.25.0", features = ["io-util", "net", "time", "macros"] }
 anyhow = "1.0"
 thiserror = "1.0"
 tokio-stream = "0.1.9"
+futures = "0.3"
 
 # Dependencies for examples and tests
 [dev-dependencies]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -3,7 +3,7 @@
 extern crate log;
 
 use fast_socks5::{
-    server::{Config, SimpleUserPassword, Socks5Server, Socks5Socket},
+    server::{Authentication, Config, SimpleUserPassword, Socks5Server, Socks5Socket},
     Result, SocksError,
 };
 use std::future::Future;
@@ -76,8 +76,11 @@ async fn spawn_socks_server() -> Result<()> {
     config.set_request_timeout(opt.request_timeout);
     config.set_skip_auth(opt.skip_auth);
 
-    match opt.auth {
-        AuthMode::NoAuth => warn!("No authentication has been set!"),
+    let config = match opt.auth {
+        AuthMode::NoAuth => {
+            warn!("No authentication has been set!");
+            config
+        }
         AuthMode::Password { username, password } => {
             if opt.skip_auth {
                 return Err(SocksError::ArgumentInputError(
@@ -85,13 +88,13 @@ async fn spawn_socks_server() -> Result<()> {
                 ));
             }
 
-            config.set_authentication(SimpleUserPassword { username, password });
             info!("Simple auth system has been set.");
+            config.with_authentication(SimpleUserPassword { username, password })
         }
-    }
+    };
 
-    let mut listener = Socks5Server::bind(&opt.listen_addr).await?;
-    listener.set_config(config);
+    let listener = <Socks5Server>::bind(&opt.listen_addr).await?;
+    let listener = listener.with_config(config);
 
     let mut incoming = listener.incoming();
 
@@ -112,10 +115,11 @@ async fn spawn_socks_server() -> Result<()> {
     Ok(())
 }
 
-fn spawn_and_log_error<F, T>(fut: F) -> task::JoinHandle<()>
+fn spawn_and_log_error<F, T, A>(fut: F) -> task::JoinHandle<()>
 where
-    F: Future<Output = Result<Socks5Socket<T>>> + Send + 'static,
+    F: Future<Output = Result<Socks5Socket<T, A>>> + Send + 'static,
     T: AsyncRead + AsyncWrite + Unpin,
+    A: Authentication,
 {
     task::spawn(async move {
         if let Err(e) = fut.await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,12 +312,10 @@ mod test {
     ) -> Result<()> {
         let mut config = server::Config::default();
         config.set_udp_support(true);
-        match auth {
-            None => {}
-            Some(up) => {
-                config.set_authentication(up);
-            }
-        }
+        let config = match auth {
+            None => config,
+            Some(up) => config.with_authentication(up),
+        };
 
         let config = Arc::new(config);
         let listener = TcpListener::bind(proxy_addr).await?;


### PR DESCRIPTION
(#34)

This is a change I've worked on in a separate fork as I needed the authenticate function to be async. This is a breaking change, as it changes the signature of the `Authenticate` trait. This doesn't depend on [`async_trait`](https://docs.rs/async-trait/latest/async_trait/), at the cost of making the trait a bit more difficult to implement. However this allows the library user to implement `Authenticate` without boxing. 

If one didn't want to use concrete types, they could box their implementation instead:
```rust
use futures::FutureExt;

pub struct MyAuth {}

impl Authentication for MyAuth {
    type Item<'a> = Pin<Box<dyn Future<Output = bool> + Send + 'a>>;

    fn authenticate<'a>(&'a self, username: &str, password: &str) -> Self::Item<'a> {
        let username = username.to_owned();
        let password = password.to_owned();
        async {
            let _username = username;
            let _password = password;
            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
            true
        }
        .boxed()
    }
}
```

More advanced implementions can be implemented via polling. Secondly, now that `Authentication` is a associated trait, it can no longer by type erased (`dyn Authentication`) which means it is now a generic argument on `Config` (and on all structs that carry `Config`), which has led to changing some function signatures.