### PR TITLE
Feat/async trait auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.25.0", features = ["io-util", "net", "time", "macros"] }
 anyhow = "1.0"
 thiserror = "1.0"
 tokio-stream = "0.1.9"
+futures = "0.3"
 
 # Dependencies for examples and tests
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.25.0", features = ["io-util", "net", "time", "macros"] }
 anyhow = "1.0"
 thiserror = "1.0"
 tokio-stream = "0.1.9"
-futures = "0.3"
+async-trait = "0.1.68"
 
 # Dependencies for examples and tests
 [dev-dependencies]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -3,7 +3,7 @@
 extern crate log;
 
 use fast_socks5::{
-    server::{Config, SimpleUserPassword, Socks5Server, Socks5Socket},
+    server::{Authentication, Config, SimpleUserPassword, Socks5Server, Socks5Socket},
     Result, SocksError,
 };
 use std::future::Future;
@@ -76,8 +76,11 @@ async fn spawn_socks_server() -> Result<()> {
     config.set_request_timeout(opt.request_timeout);
     config.set_skip_auth(opt.skip_auth);
 
-    match opt.auth {
-        AuthMode::NoAuth => warn!("No authentication has been set!"),
+    let config = match opt.auth {
+        AuthMode::NoAuth => {
+            warn!("No authentication has been set!");
+            config
+        }
         AuthMode::Password { username, password } => {
             if opt.skip_auth {
                 return Err(SocksError::ArgumentInputError(
@@ -85,13 +88,13 @@ async fn spawn_socks_server() -> Result<()> {
                 ));
             }
 
-            config.set_authentication(SimpleUserPassword { username, password });
             info!("Simple auth system has been set.");
+            config.with_authentication(SimpleUserPassword { username, password })
         }
-    }
+    };
 
-    let mut listener = Socks5Server::bind(&opt.listen_addr).await?;
-    listener.set_config(config);
+    let listener = <Socks5Server>::bind(&opt.listen_addr).await?;
+    let listener = listener.with_config(config);
 
     let mut incoming = listener.incoming();
 
@@ -112,10 +115,11 @@ async fn spawn_socks_server() -> Result<()> {
     Ok(())
 }
 
-fn spawn_and_log_error<F, T>(fut: F) -> task::JoinHandle<()>
+fn spawn_and_log_error<F, T, A>(fut: F) -> task::JoinHandle<()>
 where
-    F: Future<Output = Result<Socks5Socket<T>>> + Send + 'static,
+    F: Future<Output = Result<Socks5Socket<T, A>>> + Send + 'static,
     T: AsyncRead + AsyncWrite + Unpin,
+    A: Authentication,
 {
     task::spawn(async move {
         if let Err(e) = fut.await {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 use crate::read_exact;
-use crate::util::target_addr::{read_address, TargetAddr, ToTargetAddr};
 use crate::util::stream::{tcp_connect, tcp_connect_with_timeout};
+use crate::util::target_addr::{read_address, TargetAddr, ToTargetAddr};
 use crate::{
     consts, new_udp_header, parse_udp_request, AuthenticationMethod, ReplyError, Result,
     Socks5Command, SocksError,
@@ -27,7 +27,10 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Config { connect_timeout: None, skip_auth: false }
+        Config {
+            connect_timeout: None,
+            skip_auth: false,
+        }
     }
 }
 
@@ -185,7 +188,7 @@ where
             _ => {
                 debug!("Don't support this auth method, reply with (0xff)");
                 self.socket
-                    .write(&[
+                    .write_all(&[
                         consts::SOCKS5_VERSION,
                         consts::SOCKS5_AUTH_METHOD_NOT_ACCEPTABLE,
                     ])
@@ -209,7 +212,7 @@ where
             }) => Ok((username, password)),
             None => Err(SocksError::AuthenticationRejected(format!(
                 "Authentication rejected, missing user pass"
-            )))
+            ))),
         }?;
 
         let user_bytes = username.as_bytes();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,12 +312,10 @@ mod test {
     ) -> Result<()> {
         let mut config = server::Config::default();
         config.set_udp_support(true);
-        match auth {
-            None => {}
-            Some(up) => {
-                config.set_authentication(up);
-            }
-        }
+        let config = match auth {
+            None => config,
+            Some(up) => config.with_authentication(up),
+        };
 
         let config = Arc::new(config);
         let listener = TcpListener::bind(proxy_addr).await?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -122,6 +122,10 @@ impl<A: Authentication> Config<A> {
         }
     }
 
+    pub fn get_authentication(&self) -> Option<Arc<A>> {
+        self.auth.as_ref().map(|a| a.clone())
+    }
+
     /// Set whether or not to execute commands
     pub fn set_execute_command(&mut self, value: bool) -> &mut Self {
         self.execute_command = value;


### PR DESCRIPTION
Based on the work of https://github.com/dizda/fast-socks5/pull/36 (thank you)

More flexibility has been added, such as
  - async_trait is being used, which makes it easier to use `async fn` for authentication
  - `allow_no_auth` flag, for scenario where we could auth the client via other parameters such as IP address, etc. so the client doesn't need to send credentials, but will be checked by the Authentication trait anyway.
  - user's account can be returned once the socket has been successfully upgraded to socks5 (hence successfully authenticated), so no need to use black magic anymore to do so