### PR TITLE
fix: protocol identification compatibility issue

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -140,7 +140,7 @@ where
         packet.extend(auth);
 
         self.socket
-            .write(&packet)
+            .write_all(&packet)
             .await
             .context("Couldn't write SOCKS version & methods len & supported auth methods")?;
 
@@ -222,7 +222,7 @@ where
         packet.extend(pass_bytes);
 
         self.socket
-            .write(&packet)
+            .write_all(&packet)
             .await
             .context("Can't send password")?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -128,23 +128,21 @@ where
         methods: Vec<AuthenticationMethod>,
     ) -> Result<Vec<AuthenticationMethod>> {
         debug!(
-            "Send version and method len [{}, {}]",
+            "Client's version and method len [{}, {}]",
             consts::SOCKS5_VERSION,
             methods.len()
         );
-        // write the first 2 bytes which contains the SOCKS version and the methods len()
-        self.socket
-            .write(&[consts::SOCKS5_VERSION, methods.len() as u8])
-            .await
-            .context("Couldn't write SOCKS version & methods len")?;
+        // the first 2 bytes which contains the SOCKS version and the methods len()
+        let mut request = vec![consts::SOCKS5_VERSION, methods.len() as u8];
 
         let auth = methods.iter().map(|l| l.as_u8()).collect::<Vec<_>>();
-
         debug!("client auth methods supported: {:?}", &auth);
+        request.extend(auth);
+
         self.socket
-            .write(&auth)
+            .write(&request)
             .await
-            .context("Couldn't write supported auth methods")?;
+            .context("Couldn't write SOCKS version & methods len & supported auth methods")?;
 
         // Return methods available
         Ok(methods)

--- a/src/client.rs
+++ b/src/client.rs
@@ -133,14 +133,14 @@ where
             methods.len()
         );
         // the first 2 bytes which contains the SOCKS version and the methods len()
-        let mut request = vec![consts::SOCKS5_VERSION, methods.len() as u8];
+        let mut packet = vec![consts::SOCKS5_VERSION, methods.len() as u8];
 
         let auth = methods.iter().map(|l| l.as_u8()).collect::<Vec<_>>();
         debug!("client auth methods supported: {:?}", &auth);
-        request.extend(auth);
+        packet.extend(auth);
 
         self.socket
-            .write(&request)
+            .write(&packet)
             .await
             .context("Couldn't write SOCKS version & methods len & supported auth methods")?;
 
@@ -216,13 +216,13 @@ where
         let user_bytes = username.as_bytes();
         let pass_bytes = password.as_bytes();
 
-        let mut message: Vec<u8> = vec![1, user_bytes.len() as u8];
-        message.extend(user_bytes);
-        message.push(pass_bytes.len() as u8);
-        message.extend(pass_bytes);
+        let mut packet: Vec<u8> = vec![1, user_bytes.len() as u8];
+        packet.extend(user_bytes);
+        packet.push(pass_bytes.len() as u8);
+        packet.extend(pass_bytes);
 
         self.socket
-            .write(&message)
+            .write(&packet)
             .await
             .context("Can't send password")?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -216,23 +216,13 @@ where
         let user_bytes = username.as_bytes();
         let pass_bytes = password.as_bytes();
 
-        // send username len
-        self.socket
-            .write(&[1, user_bytes.len() as u8])
-            .await
-            .context("Can't send username len")?;
-        self.socket
-            .write(user_bytes)
-            .await
-            .context("Can't send username")?;
+        let mut message: Vec<u8> = vec![1, user_bytes.len() as u8];
+        message.extend(user_bytes);
+        message.push(pass_bytes.len() as u8);
+        message.extend(pass_bytes);
 
-        // send password len
         self.socket
-            .write(&[pass_bytes.len() as u8])
-            .await
-            .context("Can't send password len")?;
-        self.socket
-            .write(pass_bytes)
+            .write(&message)
             .await
             .context("Can't send password")?;
 


### PR DESCRIPTION
the protocol version number 0x05 and number of authentication methods were being sent in separate TCP packets. Some clients were unable to decipher this as a valid socks5 negotiation and were subsequently refusing connection.