### PR TITLE
Expose socks command in server

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -718,6 +718,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin, A: Authentication> Socks5Socket<T, A> {
         &self.auth
     }
 
+    pub fn cmd(&self) -> &Option<Socks5Command> {
+        &self.cmd
+    }
+
     /// Borrow the credentials of the user has authenticated with
     pub fn get_credentials(&self) -> Option<&<<A as Authentication>::Item as Deref>::Target>
     where


### PR DESCRIPTION
Add getter to retrieve the socks5 command.
This is useful to know if the request is a UDP association or TCP connect. There is no other method to know that otherwise