### PR TITLE
Add Eq & Hash derive for TargetAddr

### DIFF
--- a/src/util/target_addr.rs
+++ b/src/util/target_addr.rs
@@ -35,7 +35,7 @@ pub enum AddrError {
 }
 
 /// A description of a connection target.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TargetAddr {
     /// Connect to an IP address.
     Ip(SocketAddr),


### PR DESCRIPTION
Useful when we want to use TargetAddr as a key of a map