### PR TITLE
Allow to override the default command executor

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -136,7 +136,7 @@ async fn spawn_socks_server() -> Result<()> {
 fn spawn_and_log_error<F, T>(fut: F) -> task::JoinHandle<()>
 where
     F: Future<Output = Result<Socks5Socket<T, SimpleUserPassword>>> + Send + 'static,
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: AsyncRead + AsyncWrite + Unpin + Send,
 {
     task::spawn(async move {
         match fut.await {

--- a/examples/simple_tcp_server.rs
+++ b/examples/simple_tcp_server.rs
@@ -111,7 +111,7 @@ async fn spawn_socks_server() -> Result<()> {
 fn spawn_and_log_error<F, T, A>(fut: F) -> task::JoinHandle<()>
 where
     F: Future<Output = Result<Socks5Socket<T, A>>> + Send + 'static,
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: AsyncRead + AsyncWrite + Unpin + Send,
     A: Authentication,
 {
     task::spawn(async move {

--- a/src/server.rs
+++ b/src/server.rs
@@ -957,7 +957,7 @@ where
 }
 
 /// Generate reply code according to the RFC.
-fn new_reply(error: &ReplyError, sock_addr: SocketAddr) -> Vec<u8> {
+pub fn new_reply(error: &ReplyError, sock_addr: SocketAddr) -> Vec<u8> {
     let (addr_type, mut ip_oct, mut port) = match sock_addr {
         SocketAddr::V4(sock) => (
             consts::SOCKS5_ADDR_TYPE_IPV4,


### PR DESCRIPTION
Allow users to implement the connect and udp_associate commands by themselves. Users can choose any underlying protocol to implement proxy data transmission, conditional routing or chain proxies.

A simple TCP traffic interception function is implemented in `example/simple_tcp_server.rs`.

Resolve https://github.com/dizda/fast-socks5/issues/31 and https://github.com/dizda/fast-socks5/issues/15