### PR TITLE
feat(server): New async methods to validate credentials.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -478,11 +478,11 @@ impl<T> Socks5ServerProtocol<T, states::Authenticated> {
     /// same with accept_password_auth, but async.
     pub async fn accept_password_auth_async<F, R>(
         inner: T,
-        mut check: F,
+        check: F,
     ) -> Result<(Self, R), SocksServerError>
     where
         T: AsyncWrite + AsyncRead + Unpin,
-        F: AsyncFnMut(String, String) -> R,
+        F: AsyncFnOnce(String, String) -> R,
         R: CheckResult,
     {
         let (user, pass, auth) = Socks5ServerProtocol::start(inner)


### PR DESCRIPTION
Sometimes we need external services, such as Redis, to validate the credentials. An asynchronous method is needed. 

Not knowing Rust well, but Rust does not offer a function overloading mechanism… I am not sure how to modify it better.

An alternative approach, for example:
```rust
pub async fn accept_password_auth_sync<F, R>(
        inner: T,
        mut check: F,
    ) -> Result<(Self, R), SocksServerError>
    where
        T: AsyncWrite + AsyncRead + Unpin,
        F: FnMut(String, String) -> R + Send + 'static,
        R: CheckResult + Send + 'static,
    {
        Self::accept_password_auth(inner, move |user, pass| std::future::ready(check(user, pass))).await
    }
```
but doing so might have additional performance overhead.

If you have a better suggestion for modification, please let me know.

